### PR TITLE
BugFixes

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -168,14 +168,14 @@
         $scope.loadingStates.push(false); // Maintain the length of loadingStates array
         $scope.$apply(); // Apply changes
         loadActiveTab(0);
+        $scope.params = {
+          activeTab: 0
+        };
         const tabHeadings = document.querySelectorAll('.uib-tab-heading');
-        if(tabHeadings.length > 0){
+        if (tabHeadings.length > 0) {
           tabHeadings[0].focus();
         }
       }, 2000);
-      $scope.params = {
-        activeTab: 0
-      };
     };
 
     function installConnector() {
@@ -281,10 +281,10 @@
       }
       else {
         $scope.installedConnectors[connector.tabIndex].health = false;
-          $scope.toggleConnectorConfigSettings = { open: true };
-          $scope.toggleParametersSettings = { open: false };
-          $scope.toggleScheduleConfigSettings = { open: false };
-          $scope.healthyConnectors[connector.tabIndex] = false;
+        $scope.toggleConnectorConfigSettings = { open: true };
+        $scope.toggleParametersSettings = { open: false };
+        $scope.toggleScheduleConfigSettings = { open: false };
+        $scope.healthyConnectors[connector.tabIndex] = false;
       }
     });
 
@@ -394,8 +394,8 @@
               body: 'Data Ingestion successfully configured for the integration ' + healthyConnector.label
             });
             $scope.toggleConnectorConfigSettings = { open: false };
-          $scope.toggleParametersSettings = { open: true };
-          $scope.toggleScheduleConfigSettings = { open: false };
+            $scope.toggleParametersSettings = { open: true };
+            $scope.toggleScheduleConfigSettings = { open: false };
             resolve();
           })
           .catch(function (error) {
@@ -443,7 +443,7 @@
       _checkConnectorHealth();
     }
 
-    
+
     function saveParams(timParamsForm, index) {
       widgetDataIngestionService.saveDataIngestionParams($scope, timParamsForm, index);
       timParamsForm.$setPristine();
@@ -451,11 +451,11 @@
 
 
     function _checkConnectorHealth() {
-      if($scope.installedConnectors.length === 0){
+      if ($scope.installedConnectors.length === 0) {
         toaster.error({
           body: 'At least one integration configuration should be necessary.'
-      });
-      return;
+        });
+        return;
       }
       $scope.areFeedConnectorsConfigured = true;
       const promises = $scope.installedConnectors.reduce((promise, installedConnector, index) => {

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -142,18 +142,40 @@
     }
 
     $scope.removeTab = function (index) {
-      $scope.installedConnectors.splice(index, 1);
-      $scope.connectorInstalledOnAgents.splice(index, 1);
-      $scope.dataIngestCollectionUUIDs.splice(index, 1);
-      $scope.saveSchedules.splice(index, 1);
-      if ($scope.params.activeTab === index) {
-        // Set active tab to the previous tab if available
-        $scope.params.activeTab = Math.max(0, index - 1);
-      } else if ($scope.params.activeTab > index) {
-        // If the active tab was after the removed tab, decrement the active tab index
-        $scope.params.activeTab--;
-      }
-      loadActiveTab(0);
+      $scope.loadingStates[index] = true;
+      $timeout(function () {
+        // Logic to remove the tab
+        $scope.installedConnectors.splice(index, 1);
+        $scope.connectorInstalledOnAgents.splice(index, 1);
+        $scope.dataIngestCollectionUUIDs.splice(index, 1);
+        $scope.healthyConnectors.splice(index, 1);
+        $scope.saveSchedules.splice(index, 1);
+        if ($scope.params.activeTab === index) {
+          $scope.params.activeTab = 0;
+        } else if ($scope.params.activeTab > index) {
+          // If the active tab was after the removed tab, decrement the active tab index
+          $scope.params.activeTab--;
+        }
+        // Remove loading state for the specific tab
+        $scope.loadingStates.splice(index, 1);
+
+        // Adjust the active tab index accordingly
+        for (let i = 0; i < $scope.loadingStates.length; i++) {
+          if (i >= index) {
+            $scope.loadingStates[i] = $scope.loadingStates[i + 1]; // Shift the loading states
+          }
+        }
+        $scope.loadingStates.push(false); // Maintain the length of loadingStates array
+        $scope.$apply(); // Apply changes
+        loadActiveTab(0);
+        const tabHeadings = document.querySelectorAll('.uib-tab-heading');
+        if(tabHeadings.length > 0){
+          tabHeadings[0].focus();
+        }
+      }, 2000);
+      $scope.params = {
+        activeTab: 0
+      };
     };
 
     function installConnector() {
@@ -197,14 +219,16 @@
         if (CommonUtils.isUndefined($scope.params.activeTab)) {
           $scope.params = {
             activeTab: 0
-          }
+          };
         }
+        // $scope.selectedFeedConnectorName = $scope.installedConnectors[0].label;
         _loadConnectorDetails(0, $scope.installedConnectors[0]);
       }
       else {
         $scope.params = {
           activeTab: tabIndex
-        }
+        };
+        $scope.selectedFeedConnectorName = $scope.installedConnectors[tabIndex].label;
         _loadConnectorDetails(tabIndex, $scope.installedConnectors[tabIndex]);
       }
     }
@@ -235,11 +259,19 @@
       $scope.healthyConnectors[data.tabIndex] = false;
     });
 
+    $scope.$on('toggleAgentMode', function (event, data) {
+      $scope.healthyConnectors[data.tabIndex] = false;
+    });
+
     $scope.$on('healthCheckDetails', function (event, connectorDetails) {
       var connector = angular.copy(connectorDetails);
       const connectorConfig = _.find(connector.connectorInfo.configuration, { config_id: connector.config_id });
-      if (connectorConfig.status === "Available") {
-        if (!$scope.healthyConnectors[connector.tabIndex]) {
+      $scope.toggleConnectorConfigSettings = { open: true };
+      $scope.toggleParametersSettings = { open: false };
+      $scope.toggleScheduleConfigSettings = { open: false };
+      $scope.scheduleJsonData = undefined;
+      if (!CommonUtils.isUndefined(connectorConfig) && connectorConfig.status === "Available") {
+        if (!$scope.healthyConnectors[connector.tabIndex] || !_.isEmpty(connectorConfig.remote_status)) {
           $scope.installedConnectors[connector.tabIndex].health = true;
           _.assign(connector.connectorInfo, { "configuration": connectorConfig });
           _.assign(connector.connectorInfo, { "playbook_collections": connector.connectorInfo.playbook_collections[0] });
@@ -249,10 +281,10 @@
       }
       else {
         $scope.installedConnectors[connector.tabIndex].health = false;
-        $scope.toggleConnectorConfigSettings = { open: true };
-        $scope.toggleParametersSettings = { open: false };
-        $scope.toggleScheduleConfigSettings = { open: false };
-        $scope.healthyConnectors[connector.tabIndex] = false;
+          $scope.toggleConnectorConfigSettings = { open: true };
+          $scope.toggleParametersSettings = { open: false };
+          $scope.toggleScheduleConfigSettings = { open: false };
+          $scope.healthyConnectors[connector.tabIndex] = false;
       }
     });
 
@@ -343,22 +375,33 @@
     }
 
     function _processDataIngestion(tabIndex, healthyConnector) {
-      // Return a promise to initiate the chain
       return new Promise((resolve, reject) => {
-        widgetDataIngestionService.cloneIngestionPlaybookCollection($scope, healthyConnector).then(function () {
-          widgetDataIngestionService.prepareFetchSampleConfig($scope, tabIndex, healthyConnector).then(function () {
-            $scope.dataIngestCollectionUUIDs[tabIndex] = $scope.ingestCollectionUUID
-            _createDefaultSchedule(tabIndex, $scope.healthyConnectorsParams[tabIndex]);
+        widgetDataIngestionService.cloneIngestionPlaybookCollection($scope, healthyConnector)
+          .then(function () {
+            return widgetDataIngestionService.prepareFetchSampleConfig($scope, tabIndex, healthyConnector);
+          })
+          .then(function () {
+            // Wrapping _createDefaultSchedule in a promise to ensure it completes before moving on
+            return new Promise((resolve) => {
+              _createDefaultSchedule(tabIndex, $scope.healthyConnectorsParams[tabIndex]);
+              resolve(); // Resolving after _createDefaultSchedule finishes
+            });
+          })
+          .then(function () {
+            $scope.dataIngestCollectionUUIDs[tabIndex] = $scope.ingestCollectionUUID;
             $scope.healthyConnectors[tabIndex] = true;
             toaster.success({
               body: 'Data Ingestion successfully configured for the integration ' + healthyConnector.label
             });
+            $scope.toggleConnectorConfigSettings = { open: false };
+          $scope.toggleParametersSettings = { open: true };
+          $scope.toggleScheduleConfigSettings = { open: false };
             resolve();
+          })
+          .catch(function (error) {
+            console.error('Error processing healthyConnectors:', error);
+            reject(error);
           });
-        }).catch(error => {
-          console.error('Error processing healthyConnectors:', error);
-          reject(error); // Reject if there's an error
-        });
       });
     }
 
@@ -386,13 +429,13 @@
         if (response['hydra:member'].length === 0) {
           $resource(API.WORKFLOW + 'api/scheduled/?format').save(queryBody).$promise.then(function (postResponse) {
             $scope.saveSchedules[tabIndex] = postResponse;
+            $scope.scheduleJsonData = angular.copy(ingestionConnectorDetails);
           });
         }
         else {
           $scope.saveSchedules[tabIndex] = response['hydra:member'][0];
-          console.log(response);
+          $scope.scheduleJsonData = angular.copy(ingestionConnectorDetails);
         }
-        $scope.scheduleJsonData = angular.copy(ingestionConnectorDetails);
       });
     }
 
@@ -400,12 +443,20 @@
       _checkConnectorHealth();
     }
 
+    
     function saveParams(timParamsForm, index) {
-      widgetDataIngestionService.saveDataIngestionParams($scope, timParamsForm, index)
+      widgetDataIngestionService.saveDataIngestionParams($scope, timParamsForm, index);
+      timParamsForm.$setPristine();
     }
 
 
     function _checkConnectorHealth() {
+      if($scope.installedConnectors.length === 0){
+        toaster.error({
+          body: 'At least one integration configuration should be necessary.'
+      });
+      return;
+      }
       $scope.areFeedConnectorsConfigured = true;
       const promises = $scope.installedConnectors.reduce((promise, installedConnector, index) => {
         return promise.then(() => {
@@ -437,7 +488,7 @@
               const metaData = {
                 "name": $scope.saveSchedules[index].name,
                 "description": "Metadata for " + $scope.saveSchedules[index].description,
-                "modified_by": "3451141c-bac6-467c-8d72-85e0fab569ce",
+                "modified_by": "3451141c-bac6-467c-8d72-85e0fab569ce", //CSAdmin user uuid
                 "owners": [],
                 "connector": {
                   "name": configConnector.name,
@@ -573,17 +624,20 @@
     }
 
     function moveToConfigureConnector() {
+      $scope.selectedFeedConnectorName = fortiGuardConnectorName;
       $scope.fetchingAvailableConnectors = false;
       $scope.installedConnectors = $scope.feedConnectors.filter(connector => connector.installed === true && connector.selectConnector === true);
       const fortiGuardConnector = _.find($scope.installedConnectors, { label: fortiGuardConnectorName });
       const filteredConnectors = _.filter($scope.installedConnectors, connector => connector.label !== fortiGuardConnectorName);
       const sortedConnectors = _.sortBy(filteredConnectors, 'label');
       $scope.installedConnectors = [fortiGuardConnector].concat(sortedConnectors);
+      $scope.loadingStates = [];
       $scope.healthyConnectors = [];
       $scope.connectorHealthStatus = [];
       $scope.connectorParamsStatus = [];
       $scope.installedConnectors.reduce((promise, installedConnector, index) => {
         return promise.then(() => {
+          $scope.loadingStates[index] = false;
           installedConnector.health = false;
           $scope.healthyConnectors[index] = false;
           $scope.connectorHealthStatus[index] = false;
@@ -597,7 +651,7 @@
         .catch(error => {
           console.error('Error processing connectors:', error);
         });
-      loadActiveTab($state.params.tabIndex, $state.params.tab);
+      loadActiveTab($scope.params.activeTab);
       WizardHandler.wizard('timSolutionpackConfigWizard').next();
     }
 

--- a/widget/view.html
+++ b/widget/view.html
@@ -190,7 +190,7 @@
                     <p class="font-Size-13 muted"><span>This page shows the installation status of the feed integrations
                             you selected on the previous page.</span></p>
                     <p class="font-Size-13 muted">
-                        <span>Total Connectors {{getSelectedConnectorsCount}}</span>
+                        <span>Total Connectors: {{getSelectedConnectorsCount}}</span>
                     </p>
                     <div ng-if="connector.selectConnector" ng-repeat="connector in feedConnectors"
                         class="padding-5 display-flex-space-between"
@@ -239,12 +239,14 @@
                             <uib-tabset active="params.activeTab" class="margin-top-11 width-100pt">
                                 <uib-tab data-ng-repeat="timTool in installedConnectors track by $index" index="$index"
                                     data-ng-click="loadActiveTab($index)">
-                                    <uib-tab-heading>
-                                        <span class="tab-label padding-left-sm">{{ timTool.label }}</span>
-                                        <button type="button" class="close-icon font-9px font-color-danger"
-                                            ng-click="removeTab($index); $event.stopPropagation(); $event.preventDefault();">
-                                            <i class="icon icon-close"></i>
-                                        </button>
+                                    <uib-tab-heading tabindex="0">
+                                        <span class="tab-label padding-left-sm" aria-label="Close">{{ timTool.label }}
+                                            <span
+                                                data-ng-click="removeTab($index); $event.stopPropagation(); $event.preventDefault();"
+                                                class="close-tab-button" role="button" tabindex="$index">
+                                                <i class="fa margin-left-sm"
+                                                    data-ng-class="loadingStates[$index] ? 'fa-spin fa-spinner' : 'icon icon-close'"></i>
+                                            </span></span>
                                     </uib-tab-heading>
                                     <div class="col-md-5 display-flex align-items-center">
                                         <div class="full-width info-graphic-margin">
@@ -252,7 +254,7 @@
                                         </div>
                                     </div>
                                     <div class="col-md-7 padding-left-0 prerequisites-section">
-                                        <form name="params.timConfigForm">
+                                        <form name="timConfigForm" data-ng-if="timTool.label === selectedFeedConnectorName">
                                             <div
                                                 class="font-size-25 line-height-1 margin-bottom-lg margin-top-18 muted-80">
                                                 Configure {{ timTool.label }}</div>
@@ -287,8 +289,8 @@
                                                                         content-detail="timTool"
                                                                         configured-agents="connectorInstalledOnAgents[$index]"
                                                                         close-panel="handleClose()" owners="owners"
-                                                                        tab-index="$index"
-                                                                        ng-if="params.activeTab === $index"></widget-connector-configuration-component>
+                                                                        tab-index="$index">
+                                                                    </widget-connector-configuration-component>
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -322,38 +324,41 @@
                                                                     Configuration Name:
                                                                     {{healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.configuration.name}}
                                                                 </h6>
-                                                                <div ng-form="params.timConfigForm[healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name]"
-                                                                    name="params.timConfigForm[healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name]"
+                                                                <div
                                                                     data-ng-if="healthyConnectorsParams[$index].ingestionPlaybook.fetchOperation">
-                                                                    <cs-connector-field-renderer
-                                                                        data-cs-form="params.timConfigForm[healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name]"
-                                                                        data-enable-jinja="false"
-                                                                        data-json-fields="healthyConnectorsParams[$index].ingestionPlaybook.fetchOperation"
-                                                                        data-params="healthyConnectorsParams[$index].ingestionPlaybook.fetchConfiguration"
-                                                                        data-connector-data="{'connector':healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector,'version':ingestionDetails.ingestionPlaybook.ingestionConnector.version, 'configuration':ingestionDetails.ingestionPlaybook.ingestionConnector.configuration}"
-                                                                        data-on-field-change="configFieldChanged"
-                                                                        data-show-subtitle="true">
-                                                                    </cs-connector-field-renderer>
+                                                                    <div>
+                                                                        <cs-connector-field-renderer
+                                                                            data-cs-form="timConfigForm"
+                                                                            data-enable-jinja="false"
+                                                                            data-json-fields="healthyConnectorsParams[$index].ingestionPlaybook.fetchOperation"
+                                                                            data-params="healthyConnectorsParams[$index].ingestionPlaybook.fetchConfiguration"
+                                                                            data-connector-data="{'connector':healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector,'version':ingestionDetails.ingestionPlaybook.ingestionConnector.version, 'configuration':ingestionDetails.ingestionPlaybook.ingestionConnector.configuration}"
+                                                                            data-on-field-change="configFieldChanged"
+                                                                            data-show-subtitle="true">
+                                                                        </cs-connector-field-renderer>
+                                                                        <button
+                                                                            id="params-edit-save-{{healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name}}"
+                                                                            type="button"
+                                                                            data-ng-if="dataIngestionParamsUpdating === false && allowPlaybookEdit"
+                                                                            class="margin-15 btn btn-sm btn-primary"
+                                                                            data-ng-disabled="!timConfigForm.$dirty"
+                                                                            data-ng-click="saveParams(timConfigForm, $index)">
+                                                                            <i
+                                                                                class="icon icon-check margin-right-sm"></i>Save
+                                                                        </button>
+                                                                        <button
+                                                                            data-ng-if="dataIngestionParamsUpdating === true"
+                                                                            type="button"
+                                                                            class="margin-15 btn btn-sm btn-primary"
+                                                                            data-ng-disabled="dataIngestionParamsUpdating === true"
+                                                                            id="saving-edit-params-{{healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name}}">
+                                                                            <cs-spinner
+                                                                                class="pull-left margin-top-xsm state-wait button-spinner margin-right-sm"
+                                                                                data-show-background="true"
+                                                                                data-no-margin="margin-0"></cs-spinner>Saving
+                                                                        </button>
+                                                                    </div>
                                                                 </div>
-                                                            </div>
-                                                            <div class="margin-15">
-                                                                <button id="params-edit-save" type="button"
-                                                                    data-ng-if="dataIngestionParamsUpdating === false && allowPlaybookEdit"
-                                                                    class="btn btn-sm btn-primary"
-                                                                    data-ng-disabled="!params.timConfigForm[healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name].$dirty"
-                                                                    data-ng-click="saveParams(params.timConfigForm[healthyConnectorsParams[$index].ingestionPlaybook.ingestionConnector.name], $index)">
-                                                                    <i class="icon icon-check margin-right-sm"></i>Save
-                                                                </button>
-                                                                <button
-                                                                    data-ng-if="dataIngestionParamsUpdating === true"
-                                                                    type="button" class="btn btn-sm btn-primary"
-                                                                    data-ng-disabled="dataIngestionParamsUpdating === true"
-                                                                    id="saving-edit-params">
-                                                                    <cs-spinner
-                                                                        class="pull-left margin-top-xsm state-wait button-spinner margin-right-sm"
-                                                                        data-show-background="true"
-                                                                        data-no-margin="margin-0"></cs-spinner>Saving
-                                                                </button>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -382,13 +387,11 @@
                                                         <div class="padding-left-lg margin-top-negative-20">
                                                             <div
                                                                 class="padding-left-lg padding-right-lg overflow-auto query-section">
-                                                                <div
-                                                                    data-ng-if="scheduleJsonData.ingestionPlaybook.ingestPlaybook">
+                                                                <div data-ng-if="scheduleJsonData.ingestionPlaybook.ingestPlaybook">
                                                                     <div class="margin-left-md"
                                                                         data-tim-schedule-playbook
                                                                         view-widget-vars="viewWidgetVars"
-                                                                        json-data="scheduleJsonData"
-                                                                        ng-if="params.activeTab === $index">
+                                                                        json-data="scheduleJsonData">
                                                                     </div>
                                                                 </div>
                                                             </div>
@@ -445,7 +448,7 @@
                                         <div class="queue-card-header-text margin-right-3">Feed To
                                             Indicator Linking</div>
                                         <div class="margin-right-md">
-                                            <label class="margin-0 switch switch-pill switch-label switch-success">
+                                            <label class="margin-0 switch switch-pill switch-label switch-success" data-ng-click="$event.stopPropagation();">
                                                 <input type="checkbox" class="switch-input"
                                                     id="feed-to-indicator-linking-switch-slider"
                                                     name="feed-to-indicator-linking-switch-slider"
@@ -495,7 +498,7 @@
                                         <div class="queue-card-header-text margin-right-3">High Confidence
                                             Threat Feed Block</div>
                                         <div class="margin-right-md">
-                                            <label class="margin-0 switch switch-pill switch-label switch-success">
+                                            <label class="margin-0 switch switch-pill switch-label switch-success" data-ng-click="$event.stopPropagation();">
                                                 <input type="checkbox" class="switch-input"
                                                     id="high-confidence-threat-feeds-switch-slider"
                                                     name="high-confidence-threat-feeds-switch-slider"
@@ -565,7 +568,7 @@
                                         <div class="queue-card-header-text margin-right-3">
                                             Unstructured Feeds Support</div>
                                         <div class="margin-right-md">
-                                            <label class="margin-0 switch switch-pill switch-label switch-success">
+                                            <label class="margin-0 switch switch-pill switch-label switch-success" data-ng-click="$event.stopPropagation();">
                                                 <input type="checkbox" class="switch-input"
                                                     id="high-confidence-threat-feeds-switch-slider"
                                                     name="high-confidence-threat-feeds-switch-slider"

--- a/widget/widgetAssets/css/wizard-style.css
+++ b/widget/widgetAssets/css/wizard-style.css
@@ -102,3 +102,10 @@
 .selectedInstallConnector:checked:before {
 	background-color: #22a6af;
 }
+
+.close-tab-button {
+	cursor: pointer;
+	&:hover {
+		color: #22a6af;
+	}
+}

--- a/widget/widgetAssets/js/widgetConnectorConfiguration.component.js
+++ b/widget/widgetAssets/js/widgetConnectorConfiguration.component.js
@@ -511,6 +511,7 @@
     }
 
     toggleAgentMode(agentMode) {
+      self.$rootScope.$broadcast('toggleAgentMode', { 'tabIndex': self.tabIndex, 'agentMode': agentMode });
       self.formHolder.connectorForm[self.tabIndex].$setPristine();
       self.agentMode = agentMode;
       if (agentMode) {

--- a/widget/widgetAssets/js/widgetDataIngestion.service.js
+++ b/widget/widgetAssets/js/widgetDataIngestion.service.js
@@ -8,9 +8,9 @@
         .module('cybersponse')
         .factory('widgetDataIngestionService', widgetDataIngestionService);
 
-    widgetDataIngestionService.$inject = [ 'threatIntelManagementConfigurationService', 'connectorService', 'API', '_', '$filter', '$q', 'dataIngestionService', 'PagedCollection', '$resource', 'FIXED_MODULE', 'Entity', 'playbookService', 'translationService', 'toaster'];
+    widgetDataIngestionService.$inject = ['threatIntelManagementConfigurationService', 'connectorService', 'API', '_', '$filter', '$q', 'dataIngestionService', 'PagedCollection', '$resource', 'FIXED_MODULE', 'Entity', 'playbookService', 'translationService', 'toaster'];
 
-    function widgetDataIngestionService( threatIntelManagementConfigurationService, connectorService, API, _, $filter, $q, dataIngestionService, PagedCollection, $resource, FIXED_MODULE, Entity, playbookService, translationService, toaster) {
+    function widgetDataIngestionService(threatIntelManagementConfigurationService, connectorService, API, _, $filter, $q, dataIngestionService, PagedCollection, $resource, FIXED_MODULE, Entity, playbookService, translationService, toaster) {
 
         var service = {
             cloneIngestionPlaybookCollection: cloneIngestionPlaybookCollection,
@@ -75,7 +75,7 @@
                 .catch(error => {
                     console.error('Error in cloneIngestionPlaybookCollection:', error);
                     return Promise.reject(error); // Handle errors
-                });   
+                });
         }
 
         //Retrieve the sample configuration parameters from the fetch playbook.
@@ -134,7 +134,7 @@
                         return Promise.reject(error); // Handle errors
                     });
             }
-            else{
+            else {
                 return new Promise((resolve, reject) => {
                     resolve();
                 });
@@ -200,6 +200,9 @@
                 scope.dataIngestionParamsUpdating = false;
                 timParamsForm.$dirty = false;
                 scope.connectorParamsStatus[index] = true;
+                scope.toggleConnectorConfigSettings = { open: false };
+                scope.toggleParametersSettings = { open: false };
+                scope.toggleScheduleConfigSettings = { open: true };
             }).catch(error => {
                 // Handle any errors if needed
                 console.error('Error in _updateConfigPrams:', error);
@@ -208,56 +211,56 @@
         }
 
         async function _updateConfigPrams(scope, healthyConnectorsParam) {
-                // Step 1: Get filtered modules
-                scope.filteredModules = _getIngestionModules(scope.modules, healthyConnectorsParam);
-                let moduleList = scope.filteredModules.length > 0 ? scope.filteredModules : [];
-                scope.moduleType = scope.filteredModules.length > 0 ? scope.filteredModules[0].type : moduleList[0].type;
-                // Step 2: Validate existing playbook
-                healthyConnectorsParam.processing = false;
-                let selectedPlaybook = healthyConnectorsParam.ingestionPlaybook.fetchPlaybook;
-                healthyConnectorsParam.ingestionPlaybook.fetchConfigurationCopy = angular.copy(healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
-                if (playbookService.isTagAvailable(selectedPlaybook, 'fetch', threatIntelManagementConfigurationService.ingestionRecordTags)) {
-                    healthyConnectorsParam.processing = true;
-                    // Step 3: Set fields asynchronously
-                    try {
-                        await _setFields(scope, moduleList);
-                        // Step 4: Validate existing playbook after fields are set
-                        if (_validateExistingPlaybook(healthyConnectorsParam)) {
-                            let playbookId = $filter('getEndPathName')(selectedPlaybook['@id']);
-                            let fetchModified = false;
-                            let configModified = false;
-                            scope.fieldsObj = scope.fieldsObj || {};
-                            let playbookEntity = scope.samplePlaybookEntity[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name];
-                            let fetchIndex = _.isEmpty(scope.connectorFetchIndex) ? -1 : scope.connectorFetchIndex[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name].fetchIndex;
-                            let configIndex = _.isEmpty(scope.connectorConfigIndex) ? -1 : scope.connectorConfigIndex[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name].configIndex;
-                            // Step 5: Modify sample playbook data if needed
-                            if (playbookEntity) {
-                                var samplePlaybookData = playbookEntity.getData();
-                                samplePlaybookData['@id'] = playbookEntity.originalData['@id'];
-                                if (fetchIndex > -1 && (!angular.equals(samplePlaybookData.steps[fetchIndex].arguments.params, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration))) {
-                                    fetchModified = true;
-                                    samplePlaybookData.steps[fetchIndex].arguments.params = angular.extend(samplePlaybookData.steps[fetchIndex].arguments.params, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
-                                } else if (configIndex > -1 && (!angular.equals(selectedPlaybook.steps[configIndex].arguments, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration))) {
-                                    configModified = true;
-                                    selectedPlaybook.steps[configIndex].arguments = angular.extend(selectedPlaybook.steps[configIndex].arguments, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
-                                    samplePlaybookData.steps[configIndex].arguments = angular.copy(selectedPlaybook.steps[configIndex].arguments);
-                                }
-                                // Step 6: Save sample playbook entity if modified
-                                if (fetchModified || configModified) {
-                                    let samplePlaybook = playbookService.preparePlaybookForSave(samplePlaybookData);
-                                    await playbookEntity.save(samplePlaybook, { $relationships: true });
-                                }
+            // Step 1: Get filtered modules
+            scope.filteredModules = _getIngestionModules(scope.modules, healthyConnectorsParam);
+            let moduleList = scope.filteredModules.length > 0 ? scope.filteredModules : [];
+            scope.moduleType = scope.filteredModules.length > 0 ? scope.filteredModules[0].type : moduleList[0].type;
+            // Step 2: Validate existing playbook
+            healthyConnectorsParam.processing = false;
+            let selectedPlaybook = healthyConnectorsParam.ingestionPlaybook.fetchPlaybook;
+            healthyConnectorsParam.ingestionPlaybook.fetchConfigurationCopy = angular.copy(healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
+            if (playbookService.isTagAvailable(selectedPlaybook, 'fetch', threatIntelManagementConfigurationService.ingestionRecordTags)) {
+                healthyConnectorsParam.processing = true;
+                // Step 3: Set fields asynchronously
+                try {
+                    await _setFields(scope, moduleList);
+                    // Step 4: Validate existing playbook after fields are set
+                    if (_validateExistingPlaybook(healthyConnectorsParam)) {
+                        let playbookId = $filter('getEndPathName')(selectedPlaybook['@id']);
+                        let fetchModified = false;
+                        let configModified = false;
+                        scope.fieldsObj = scope.fieldsObj || {};
+                        let playbookEntity = scope.samplePlaybookEntity[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name];
+                        let fetchIndex = _.isEmpty(scope.connectorFetchIndex) ? -1 : scope.connectorFetchIndex[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name].fetchIndex;
+                        let configIndex = _.isEmpty(scope.connectorConfigIndex) ? -1 : scope.connectorConfigIndex[healthyConnectorsParam.ingestionPlaybook.ingestionConnector.name].configIndex;
+                        // Step 5: Modify sample playbook data if needed
+                        if (playbookEntity) {
+                            var samplePlaybookData = playbookEntity.getData();
+                            samplePlaybookData['@id'] = playbookEntity.originalData['@id'];
+                            if (fetchIndex > -1 && (!angular.equals(samplePlaybookData.steps[fetchIndex].arguments.params, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration))) {
+                                fetchModified = true;
+                                samplePlaybookData.steps[fetchIndex].arguments.params = angular.extend(samplePlaybookData.steps[fetchIndex].arguments.params, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
+                            } else if (configIndex > -1 && (!angular.equals(selectedPlaybook.steps[configIndex].arguments, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration))) {
+                                configModified = true;
+                                selectedPlaybook.steps[configIndex].arguments = angular.extend(selectedPlaybook.steps[configIndex].arguments, healthyConnectorsParam.ingestionPlaybook.fetchConfiguration);
+                                samplePlaybookData.steps[configIndex].arguments = angular.copy(selectedPlaybook.steps[configIndex].arguments);
                             }
-                            // Step 7: Get data after modifying or if not modified
-                            _getData(scope, playbookId, selectedPlaybook, healthyConnectorsParam);
+                            // Step 6: Save sample playbook entity if modified
+                            if (fetchModified || configModified) {
+                                let samplePlaybook = playbookService.preparePlaybookForSave(samplePlaybookData);
+                                await playbookEntity.save(samplePlaybook, { $relationships: true });
+                            }
                         }
-                    } catch (error) {
-                        console.error('Error processing:', error);
-                        healthyConnectorsParam.processing = false;
+                        // Step 7: Get data after modifying or if not modified
+                        _getData(scope, playbookId, selectedPlaybook, healthyConnectorsParam);
                     }
-                } else {
+                } catch (error) {
+                    console.error('Error processing:', error);
                     healthyConnectorsParam.processing = false;
                 }
+            } else {
+                healthyConnectorsParam.processing = false;
+            }
         }
 
         function _getIngestionModules(modules, healthyConnectorsParam) {


### PR DESCRIPTION
### BugFixes
- Fixed: 1091073 | Fixed the issue of Close tab button in `Configure the Feed Config` page
- Fixed: 1091073 | Added colon in `Total connector 2` label in `Install Feed Integration` page
- Fixed: 1092490 | The ingestion schedule has been updated with incorrect configuration settings.
- Fixed: 1092485 | The save button for the ingestion schedule gets stuck on "saving" indefinitely
- Fixed: 1092476 | Fortinet Fortiguard Connector is not marked for default configuration.
- Fixed: 1092388 | After closing all the connector tabs on the configure feed page, user is still able to proceed without connector config
- Fixed: 1092014 | Single schedule is getting created for multiple configuration may it be self or agent. 
- Fixed: 1091583 | User is not able to change Ingestion parameters which are already been chaanged once, hence the save button is disabled.

### Test Case:
- Tested the `Close Tab` button matches to all the theme
- Tested colon in `Total connector 2` label in `Install Feed Integration` page
- Tested Fortinet Fortiguard Connector is not marked for default configuration.
- Tested all schedule modification belongs to its associated connector config
- Every configuration separate schedule is crated 
- After closing all the tabs then added toaster `At least one integration configuration should be necessary.`
- User can change the ingestion parameters  multiple times